### PR TITLE
Add Keys() and Dump()

### DIFF
--- a/critbit.go
+++ b/critbit.go
@@ -190,3 +190,56 @@ func iterate(p ref, h func(string) bool) bool {
 	}
 	return h(p.string)
 }
+
+// Keys returns all keys, as a slice of strings, in sorted order.
+func (t *Tree) Keys() []string {
+	keys := make([]string, 0, t.length)
+
+	// empty tree?
+	if t.root == nil {
+		return keys
+	}
+
+	// Walk the tree without function recursion
+	to_visit := make([]*ref, 1)
+
+	// Walk the left side of the root
+	p := t.root
+	to_visit[0] = p
+
+	for len(to_visit) > 0 {
+		// shift the list to get the first item
+		p, to_visit = to_visit[0], to_visit[1:]
+
+		// leaf?
+		if p.node == nil {
+			keys = append(keys, p.string)
+		} else {
+			// unshift the children and continue
+			to_visit = append([]*ref{&p.node.child[0], &p.node.child[1]},
+				to_visit...)
+		}
+	}
+	return keys
+}
+
+// Dump is useful for debugging. It println()'s the entire tree
+func (t *Tree) Dump() {
+	println("Tree length=", t.length)
+	println("Root: off=", t.root.off, "bit=", t.root.bit, "string=", t.root.string)
+	if t.root != nil {
+		t.root.dump("")
+	}
+}
+
+// dump is a helper function for Tree.Dump()
+func (n *node) dump(indent string) {
+	println(indent, "Left:  off=", n.off, "bit=", n.bit, "string=", n.child[0].string)
+	if n.child[0].node != nil {
+		n.child[0].node.dump(indent + "    ")
+	}
+	println(indent, "Right: off=", n.off, "bit=", n.bit, "string=", n.child[1].string)
+	if n.child[1].node != nil {
+		n.child[1].node.dump(indent + "    ")
+	}
+}

--- a/critbit_test.go
+++ b/critbit_test.go
@@ -121,3 +121,55 @@ func TestIterate(t *testing.T) {
 		})
 	}
 }
+
+func testStringsEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestKeys0(t *testing.T) {
+	tr := &Tree{}
+	expected := []string{}
+
+	returned_keys := tr.Keys()
+	if !testStringsEq(returned_keys, expected) {
+		t.Errorf("Got: %q", returned_keys)
+	}
+}
+
+func TestKeys1(t *testing.T) {
+	tr := &Tree{}
+	orig_keys := []string{"aa"}
+	expected := []string{"aa"}
+
+	for _, s := range orig_keys {
+		tr.Insert(s)
+	}
+	returned_keys := tr.Keys()
+	if !testStringsEq(returned_keys, expected) {
+		t.Errorf("Got: %q", returned_keys)
+	}
+}
+
+func TestKeysMany(t *testing.T) {
+	tr := &Tree{}
+	orig_keys := []string{"zz", "dd", "yy", "cc", "xx", "bb", "ww", "aa"}
+	expected := []string{"aa", "bb", "cc", "dd", "ww", "xx", "yy", "zz"}
+
+	for _, s := range orig_keys {
+		tr.Insert(s)
+	}
+	returned_keys := tr.Keys()
+	if !testStringsEq(returned_keys, expected) {
+		t.Errorf("Got: %q", returned_keys)
+	}
+}


### PR DESCRIPTION
Keys() returns a string-slice of all the keys in the tree. It does
a depth-first-search of the tree, but using a stack of pointers
instead of recursively calling a node-walking function. The string
slice of keys is in sorted order, naturally.

Dump() is a helper function which println()'s the entire tree.
This is helpful when debugging, to see what the tree looks like.
